### PR TITLE
Rename webpack.mix.js to webpack.mix.js - fix

### DIFF
--- a/webpack.mix.js - fix
+++ b/webpack.mix.js - fix
@@ -1,0 +1,8 @@
+const { mix } = require('laravel-mix');
+
+ mix.sass('src/sass/app.scss', 'dist/css')
+    .js('src/js/app.js', 'dist/js')
+    .sourceMaps()
+    .setPublicPath('dist');
+//it doesn't work on windows 10 powershell, stuck on 95% emitted, while run yurn or npm run dev. just add the .setPublicPath('');
+// thank you for this awsome guide.


### PR DESCRIPTION
//it doesn't work on windows 10 powershell, stuck on 95% emitted, while run yurn or npm run dev. just add the .setPublicPath('');
// thank you for this awsome guide.